### PR TITLE
Guard against dangerous TTL behavior

### DIFF
--- a/lib/fernet/verifier.rb
+++ b/lib/fernet/verifier.rb
@@ -5,14 +5,29 @@ require 'date'
 
 module Fernet
   class Verifier
-    attr_reader :token, :data
-    attr_accessor :ttl, :enforce_ttl
+    attr_reader :token, :data, :ttl, :enforce_ttl
 
     def initialize(secret, decrypt)
       @secret      = Secret.new(secret, decrypt)
       @decrypt     = decrypt
       @ttl         = Configuration.ttl
       @enforce_ttl = Configuration.enforce_ttl
+    end
+
+    def ttl=(value)
+      if @valid.nil?
+        @ttl = value
+      else
+        raise ArgumentError, "Already verified"
+      end
+    end
+
+    def enforce_ttl=(value)
+      if @valid.nil?
+        @enforce_ttl = value
+      else
+        raise ArgumentError, "Already verified"
+      end
     end
 
     def verify_token(token)

--- a/spec/fernet_spec.rb
+++ b/spec/fernet_spec.rb
@@ -90,6 +90,20 @@ describe Fernet do
     ).to be_true
   end
 
+  it 'forbids changes to validation parameters post validation' do
+    token = Fernet.generate(secret) do |generator|
+      generator.data = token_data
+    end
+
+    verifier = Fernet.verifier(secret, token) do |verifier|
+      def verifier.now
+        Time.now + 99999999999
+      end
+    end
+    expect { verifier.enforce_ttl = false }.to raise_error
+    expect { verifier.ttl = 999999999999 }.to raise_error
+  end
+
   it 'can ignore TTL enforcement via global config' do
     Fernet::Configuration.run do |config|
       config.enforce_ttl = false


### PR DESCRIPTION
Fernet allows you to change `enforce_ttl` and `ttl` on a verifier _after_ verification has already happened (it then just ignores them). Due to the subtle way verification works with `Fernet::Verifier`, I've seen three people (including myself) make this mistake and fail to turn properly adjust TTL settings.

I think the right solution is some change in API that makes it explicit that verification has already occurred and these flags are meaningless. I've toyed with having changes trigger a re-verification of the token, but that seems like an awkward functionality. I've also tried to think of a different approach to the API, but don't have any great ideas. I've considered removing the explicit `verify_token` step and do verification implicitly by passing the token in to `#valid?`, but that changes the semantics somewhat (i.e., you would no longer cache the verification step, and would just re-verify every time you wanted to check validity).

In the meantime, this change ensures that if someone does try to use Fernet incorrectly, it fails fast.
