### PR TITLE
Make Fernet compatible with the written spec and the Go version

### DIFF
--- a/lib/fernet/generator.rb
+++ b/lib/fernet/generator.rb
@@ -16,10 +16,10 @@ module Fernet
       yield self if block_given?
       iv, encrypted_data = encrypt
       issued_timestamp = Time.now.to_i
-      payload = BitPacking.pack_int64_bigendian(issued_timestamp) +
+      payload = [Fernet::TOKEN_VERSION].pack("C") +
+        BitPacking.pack_int64_bigendian(issued_timestamp) +
         iv + encrypted_data
       mac = OpenSSL::HMAC.digest('sha256', secret.signing_key, payload)
-      [Fernet::TOKEN_VERSION].pack("C") +
         Base64.urlsafe_encode64(payload + mac)
     end
 


### PR DESCRIPTION
The token is currently written as 0x80 || Base64(TS || IV || Cipher || HMAC), with the HMAC payload being (TS || IV || Cipher) while the Go version and the spec written at github.com/kr/fernet-spec are using Base64(0x80 || TS || IV || Cipher || HMAC) with the Fernet version also being used in the HMAC payload.

This patch changes the generator and verifier so they use the spec, but it will break old tokens.
