### PR TITLE
Move call to super to the beginning of the method

### DIFF
--- a/lib/fernet/token.rb
+++ b/lib/fernet/token.rb
@@ -89,6 +89,7 @@ module Fernet
     end
 
     def validate
+      super
       if valid_base64?
         if unknown_token_version?
           errors.add :version, "is unknown"
@@ -109,7 +110,6 @@ module Fernet
       else
         errors.add(:token, "invalid base64")
       end
-      super
     end
 
     def regenerated_mac


### PR DESCRIPTION
Valcro's own validate method clear all errors before executing, and so it clears too all Token's errors, resulting in a always valid token, no matters its content.

I ensure Token's validation are executed after the Valcro's validators.
