### PR TITLE
Fix spelling error in deprecation message

### DIFF
--- a/lib/fernet/verifier.rb
+++ b/lib/fernet/verifier.rb
@@ -42,7 +42,7 @@ module Fernet
 
     # Deprecated: returns the token's message
     def data
-      puts "[WARNING] data is deprected. Use message instead"
+      puts "[WARNING] data is deprecated. Use message instead"
       message
     end
 


### PR DESCRIPTION
Correct spelling error in deprecation message
