### PR TITLE
Unify errors under a parent class

### DIFF
--- a/lib/fernet.rb
+++ b/lib/fernet.rb
@@ -1,3 +1,4 @@
+require 'fernet/errors'
 require 'fernet/version'
 require 'fernet/bit_packing'
 require 'fernet/encryption'

--- a/lib/fernet/errors.rb
+++ b/lib/fernet/errors.rb
@@ -1,0 +1,3 @@
+module Fernet
+  class Error < StandardError; end
+end

--- a/lib/fernet/secret.rb
+++ b/lib/fernet/secret.rb
@@ -1,10 +1,11 @@
 require 'base64'
+require_relative 'errors'
 
 module Fernet
   # Internal: Encapsulates a secret key, a 32-byte sequence consisting
   #   of an encryption and a signing key.
   class Secret
-    class InvalidSecret < RuntimeError; end
+    class InvalidSecret < Fernet::Error; end
 
     # Internal - Initialize a Secret
     #

--- a/lib/fernet/token.rb
+++ b/lib/fernet/token.rb
@@ -1,13 +1,14 @@
 # encoding UTF-8
 require 'base64'
 require 'valcro'
+require_relative 'errors'
 
 module Fernet
   # Internal: encapsulates a fernet token structure and validation
   class Token
     include Valcro
 
-    class InvalidToken < StandardError; end
+    class InvalidToken < Fernet::Error; end
 
     # Internal: the default token version
     DEFAULT_VERSION = 0x80.freeze

--- a/lib/fernet/verifier.rb
+++ b/lib/fernet/verifier.rb
@@ -2,11 +2,12 @@
 require 'base64'
 require 'openssl'
 require 'date'
+require_relative 'errors'
 
 module Fernet
   # Public: verifies Fernet Tokens
   class Verifier
-    class UnknownTokenVersion < RuntimeError; end
+    class UnknownTokenVersion < Fernet::Error; end
 
     attr_reader :token
     attr_accessor :ttl, :enforce_ttl


### PR DESCRIPTION
This makes it easier to rescue all Fernet errors in one place (e.g., when decrypting an encrypted payload as in [fernet-rack](https://github.com/cyberdelia/fernet-rack/pull/3)).
