### PR TITLE
Allow encryption of empty strings

### DIFF
--- a/lib/fernet/encryption.rb
+++ b/lib/fernet/encryption.rb
@@ -26,7 +26,12 @@ module Fernet
       iv = opts[:iv] || cipher.random_iv
       cipher.iv  = iv
       cipher.key = opts[:key]
-      [cipher.update(opts[:message]) + cipher.final, iv]
+      ciphertext = ""
+      if opts[:message] && !opts[:message].empty?
+        ciphertext += cipher.update(opts[:message])
+      end
+      ciphertext += cipher.final
+      [ciphertext, iv]
     end
 
     # Internal: Decrypts the provided ciphertext using a AES-128-CBC cipher with a

--- a/spec/token_spec.rb
+++ b/spec/token_spec.rb
@@ -95,4 +95,12 @@ describe Fernet::Token, 'message' do
 
     expect(token.message).to eq('hello')
   end
+
+  it 'correctly handles an empty message' do
+    token = Fernet::Token.generate(secret: secret,
+                                   message: '')
+    token.valid? or raise "invalid token"
+
+    expect(token.message).to eq('')
+  end
 end


### PR DESCRIPTION
Running `OpenSSL::Cipher#update` with an empty string results in an `ArgumentError` which prevents Fernet from working. This patch only calls `#update` conditionally, which allows encryption to go through even for an empty string.

Fixes fernet/fernet-rb#32.