### PR TITLE
Make fernet unicode-friendly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,8 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+
+# install fresh version of bundler, since older ones blow up trying to install
+# rspec
+before_install:
+  gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,3 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-
-script: bundle exec rspec -b spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: ruby
 
 rvm:
-  - "1.9.3"
-  - "1.9.2"
-  - "2.0.0"
+  - 1.9.2
+  - 1.9.3
+  - 2.0
+  - 2.1
+  - 2.2
 
 script: bundle exec rspec -b spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,7 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new
+
+task default: :spec

--- a/fernet.gemspec
+++ b/fernet.gemspec
@@ -2,18 +2,16 @@
 require File.expand_path('../lib/fernet/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Harold Giménez"]
-  gem.email         = ["harold.gimenez@gmail.com"]
-  gem.description   = %q{Delicious HMAC Digest(if) authentication and AES-128-CBC encryption}
-  gem.summary       = %q{Easily generate and verify AES encrypted HMAC based authentication tokens}
-  gem.homepage      = ""
+  gem.authors      = ["Harold Giménez"]
+  gem.email        = ["harold.gimenez@gmail.com"]
+  gem.description  = "Delicious HMAC Digest(if) authentication and AES-128-CBC encryption"
+  gem.summary      = "Easily generate and verify AES encrypted HMAC based authentication tokens"
+  gem.homepage     = "https://github.com/fernet/fernet-rb"
 
-  gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = "fernet"
-  gem.require_paths = ["lib"]
-  gem.version       = Fernet::VERSION
+  gem.files        = Dir["LICENSE", "README.md", "lib/**/**"]
+  gem.name         = "fernet"
+  gem.require_path = "lib"
+  gem.version      = Fernet::VERSION
 
   gem.add_runtime_dependency "valcro", "0.1"
   gem.add_development_dependency "rspec"

--- a/fernet.gemspec
+++ b/fernet.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |gem|
   gem.require_path = "lib"
   gem.version      = Fernet::VERSION
 
-  gem.add_runtime_dependency "valcro", "0.1"
-  gem.add_development_dependency "rspec"
+  gem.add_runtime_dependency     "valcro", "0.1"
+  gem.add_development_dependency "rspec",  "~> 3.4"
 end

--- a/fernet.gemspec
+++ b/fernet.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency     "valcro", "0.1"
   gem.add_development_dependency "rspec",  "~> 3.4"
+  gem.add_development_dependency "rake",  "~> 10.4"
 end

--- a/lib/fernet.rb
+++ b/lib/fernet.rb
@@ -23,6 +23,13 @@ module Fernet
   #
   # Returns the fernet token as a string
   def self.generate(secret, message = '', opts = {})
+    # OpenSSL::Cipher loses all encoding informaion upon decoding ciphertext
+    # and everything comes out as ASCII. To prevent that, let's just explicitly
+    # convert input value to UTF-8 so we can assume the decrypted value will
+    # also be unicode.  This is not exactly a wonderful solution, but it's
+    # better than just returning ASCII with mangled unicode bytes in it.
+    message = message.encode(Encoding::UTF_8) if message
+
     Generator.new(opts.merge({secret: secret, message: message})).
       generate
   end

--- a/lib/fernet/verifier.rb
+++ b/lib/fernet/verifier.rb
@@ -35,7 +35,7 @@ module Fernet
 
     # Public: Returns the token's message
     def message
-      @token.message
+      @token.message.dup.force_encoding(Encoding::UTF_8)
     end
 
     # Deprecated: returns the token's message

--- a/spec/fernet_spec.rb
+++ b/spec/fernet_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 require 'fernet'
 
@@ -8,11 +10,13 @@ describe Fernet do
   let(:bad_secret) { 'badICDH6x3M7duQeM8dJEMK4Y5TkBIsYDw1lPy35RiY=' }
 
   it 'can verify tokens it generates' do
-    token = Fernet.generate(secret, 'harold@heroku.com')
+    ['harold@heroku.com', '12345', 'weird!@#$%^&*()chars', 'more weird chars §§§§'].each do |plain|
+      token = Fernet.generate(secret, plain)
 
-    verifier = Fernet.verifier(secret, token)
-    expect(verifier).to be_valid
-    expect(verifier.message).to eq('harold@heroku.com')
+      verifier = Fernet.verifier(secret, token)
+      expect(verifier).to be_valid
+      expect(verifier.message).to eq(plain)
+    end
   end
 
   it 'fails with a bad secret' do


### PR DESCRIPTION
This change will implicitly encode all encryptor input to UTF-8 and
assume that the output is UTF-8 as well. This is needed because the
encoding information is inherently lost upon decryption and so we
normally wouldn't know what encoding to apply to the decrypted data.

Also, fixes #34