### PR TITLE
Add AES192 and AES256 as optional encryption methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 .rbenv-version
 .ruby-version
+.ruby-gemset

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "spec/fernet-spec"]
 	path = spec/fernet-spec
-	url = git://github.com/kr/fernet-spec.git
+	url = https://github.com/tknarr/fernet-spec.git
+	branch = enhance_aes

--- a/fernet.gemspec
+++ b/fernet.gemspec
@@ -2,9 +2,9 @@
 require File.expand_path('../lib/fernet/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors      = ["Harold Giménez"]
-  gem.email        = ["harold.gimenez@gmail.com"]
-  gem.description  = "Delicious HMAC Digest(if) authentication and AES-128-CBC encryption"
+  gem.authors      = ["Harold Giménez", "Todd Knarr"]
+  gem.email        = ["harold.gimenez@gmail.com", "tknarr@silverglass.org"]
+  gem.description  = "Delicious HMAC Digest(if) authentication and AES-128/192/256-CBC encryption"
   gem.summary      = "Easily generate and verify AES encrypted HMAC based authentication tokens"
   gem.homepage     = "https://github.com/fernet/fernet-rb"
 

--- a/lib/fernet.rb
+++ b/lib/fernet.rb
@@ -11,10 +11,13 @@ require 'fernet/configuration'
 Fernet::Configuration.run
 
 module Fernet
+  # Determine AES key bits from base64-encoded secret length
+  KEYBITS_SELECT = { 44 => 128, 64 => 192, 88 => 256 }.freeze
+
   # Public: generates a fernet token
   #
-  # secret  - a base64 encoded, 32 byte string
-  # message - the message being secured in plain text
+  # secret   - a base64 encoded 32, 48 or 64 byte string
+  # message  - the message being secured in plain text
   #
   # Examples
   #
@@ -30,7 +33,8 @@ module Fernet
     # better than just returning ASCII with mangled unicode bytes in it.
     message = message.encode(Encoding::UTF_8) if message
 
-    Generator.new(opts.merge({secret: secret, message: message})).
+    key_bits = KEYBITS_SELECT[secret.bytesize] || 128
+    Generator.new(opts.merge({secret: secret, message: message, key_bits: key_bits})).
       generate
   end
 

--- a/lib/fernet/encryption.rb
+++ b/lib/fernet/encryption.rb
@@ -21,7 +21,9 @@ module Fernet
     #
     # Returns a two-element array containing the ciphertext and the random IV
     def self.encrypt(opts)
-      cipher = OpenSSL::Cipher.new('AES-128-CBC')
+      key_bits = opts[:key].bytesize * 8
+      cipher_selection = 'AES-' + key_bits.to_s + '-CBC'
+      cipher = OpenSSL::Cipher.new(cipher_selection)
       cipher.encrypt
       iv = opts[:iv] || cipher.random_iv
       cipher.iv  = iv
@@ -50,7 +52,9 @@ module Fernet
     #
     # Returns a two-element array containing the ciphertext and the random IV
     def self.decrypt(opts)
-      decipher = OpenSSL::Cipher.new('AES-128-CBC')
+      key_bits = opts[:key].bytesize * 8
+      cipher_selection = 'AES-' + key_bits.to_s + '-CBC'
+      decipher = OpenSSL::Cipher.new(cipher_selection)
       decipher.decrypt
       decipher.iv  = opts[:iv]
       decipher.key = opts[:key]

--- a/lib/fernet/generator.rb
+++ b/lib/fernet/generator.rb
@@ -12,13 +12,15 @@ module Fernet
     # Internal: Initializes a generator
     #
     # opts - a hash containing the following keys:
-    # * secret  - a string containing a secret, optionally Base64 encoded
-    # * message - the message
+    # * key_bits - number of bits in the AES key, defaults to 128
+    # * secret   - a string containing a secret, optionally Base64 encoded
+    # * message  - the message
     def initialize(opts)
-      @secret  = opts.fetch(:secret)
-      @message = opts[:message]
-      @iv      = opts[:iv]
-      @now     = opts[:now]
+      @key_bits = opts[:key_bits] || 128
+      @secret   = opts.fetch(:secret)
+      @message  = opts[:message]
+      @iv       = opts[:iv]
+      @now      = opts[:now]
     end
 
     # Internal: generates a secret token
@@ -40,17 +42,18 @@ module Fernet
     def generate
       yield self if block_given?
 
-      token = Token.generate(secret:  @secret,
-                             message: @message,
-                             iv:      @iv,
-                             now:     @now)
+      token = Token.generate(key_bits: @key_bits,
+                             secret:   @secret,
+                             message:  @message,
+                             iv:       @iv,
+                             now:      @now)
       token.to_s
     end
 
     # Public: string representation of this generator, masks secret to avoid
     #   leaks
     def inspect
-      "#<Fernet::Generator @secret=[masked] @message=#{@message.inspect}>"
+      "#<Fernet::Generator @key_bits=#{@key_bits} @secret=[masked] @message=#{@message.inspect}>"
     end
     alias to_s inspect
 

--- a/lib/fernet/token.rb
+++ b/lib/fernet/token.rb
@@ -100,6 +100,30 @@ module Fernet
       new(Base64.urlsafe_encode64(payload + mac), secret: opts.fetch(:secret))
     end
 
+    # Internal: return the AES key length in bits based on a version byte
+    #
+    # v - version byte
+    def self.version_key_bits(v)
+      (VALID_VERSIONS.rassoc(v) || [ 0, 0 ])[0]
+    end
+
+    # Internal: return the revision of the spec based on a version byte
+    #
+    # v - version byte
+    def self.version_revision(v)
+      v & 0b00011111
+    end
+
+    # Internal: build a version byte based on a revision and AES key length
+    #
+    # key_bits - number of bits in the AES key
+    # revision - revision of the spec
+    def self.make_version(key_bits, revision)
+      base_version = VALID_VERSIONS[key_bits]
+      return 0 if base_version.nil?
+      ( base_version & 0b11100000 ) | ( revision & 0b00011111 )
+    end
+
   private
     def decoded_token
       @decoded_token ||= Base64.urlsafe_decode64(@token)

--- a/lib/fernet/token.rb
+++ b/lib/fernet/token.rb
@@ -12,6 +12,8 @@ module Fernet
 
     # Internal: the default token version
     DEFAULT_VERSION = 0x80.freeze
+    # Internet: mapping from key size to version byte
+    VALID_VERSIONS = { 128 => 0x80, 192 => 0xA0, 256 => 0xC0 }.freeze
     # Internal: max allowed clock skew for calculating TTL
     MAX_CLOCK_SKEW  = 60.freeze
 
@@ -26,7 +28,13 @@ module Fernet
     #                  Configuration.ttl
     def initialize(token, opts = {})
       @token       = token
-      @secret      = Secret.new(opts.fetch(:secret))
+      begin
+        version_byte = version
+      rescue
+        version_byte = DEFAULT_VERSION
+      end
+      key_bits, _ = VALID_VERSIONS.rassoc(version_byte) || [ 128, 0 ]
+      @secret      = Secret.new(opts.fetch(:secret), key_bits)
       @enforce_ttl = opts.fetch(:enforce_ttl) { Configuration.enforce_ttl }
       @ttl         = opts[:ttl] || Configuration.ttl
       @now         = opts[:now]
@@ -67,13 +75,15 @@ module Fernet
     # Internal: generates a Fernet Token
     #
     # opts - a hash containing
-    # * secret  - a string containing the secret, optionally base64 encoded
-    # * message - the message in plain text
+    # * secret   - a string containing the secret, optionally base64 encoded
+    # * message  - the message in plain text
+    # * key_bits - number of bits in the AES key
     def self.generate(opts)
       unless opts[:secret]
         raise ArgumentError, 'Secret not provided'
       end
-      secret = Secret.new(opts.fetch(:secret))
+      key_bits = opts[:key_bits] || 128
+      secret = Secret.new(opts.fetch(:secret), key_bits)
       encrypted_message, iv = Encryption.encrypt(
         key:     secret.encryption_key,
         message: opts[:message],
@@ -81,7 +91,7 @@ module Fernet
       )
       issued_timestamp = (opts[:now] || Time.now).to_i
 
-      version = opts[:version] || DEFAULT_VERSION
+      version = opts[:version] || VALID_VERSIONS[key_bits] || DEFAULT_VERSION
       payload = [version].pack("C") +
         BitPacking.pack_int64_bigendian(issued_timestamp) +
         iv +
@@ -176,7 +186,7 @@ module Fernet
     end
 
     def unknown_token_version?
-      DEFAULT_VERSION != version
+      VALID_VERSIONS.rassoc(version).nil?
     end
 
     def enforce_ttl?

--- a/lib/fernet/version.rb
+++ b/lib/fernet/version.rb
@@ -1,3 +1,3 @@
 module Fernet
-  VERSION = "2.2"
+  VERSION = "3.0"
 end

--- a/spec/acceptance/generate_spec.rb
+++ b/spec/acceptance/generate_spec.rb
@@ -4,7 +4,7 @@ require 'json'
 require 'base64'
 
 describe Fernet::Generator do
-  it 'generates tokens according to the spec' do
+  it 'generates tokens according to the spec for AES128' do
     path = File.expand_path(
       './../fernet-spec/generate.json', File.dirname(__FILE__)
     )
@@ -16,12 +16,57 @@ describe Fernet::Generator do
       now            = DateTime.parse(test_data['now']).to_time
       expected_token = test_data['token']
 
-      generator = Fernet::Generator.new(secret:  secret,
-                                        message: message,
-                                        iv:      iv,
-                                        now:     now)
+      generator = Fernet::Generator.new(secret:   secret,
+                                        message:  message,
+                                        iv:       iv,
+                                        now:      now)
 
       expect(generator.generate).to eq(expected_token)
     end
   end
+
+  it 'generates tokens according to the spec for AES192' do
+    path = File.expand_path(
+      './../fernet-spec/generate_192.json', File.dirname(__FILE__)
+    )
+    generate_json  = JSON.parse(File.read(path))
+    generate_json.each do |test_data|
+      message        = test_data['src']
+      iv             = test_data['iv'].pack("C*")
+      secret         = test_data['secret']
+      now            = DateTime.parse(test_data['now']).to_time
+      expected_token = test_data['token']
+
+      generator = Fernet::Generator.new(secret:   secret,
+                                        key_bits: 192,
+                                        message:  message,
+                                        iv:       iv,
+                                        now:      now)
+
+      expect(generator.generate).to eq(expected_token)
+    end
+  end
+
+  it 'generates tokens according to the spec for AES256' do
+    path = File.expand_path(
+      './../fernet-spec/generate_256.json', File.dirname(__FILE__)
+    )
+    generate_json  = JSON.parse(File.read(path))
+    generate_json.each do |test_data|
+      message        = test_data['src']
+      iv             = test_data['iv'].pack("C*")
+      secret         = test_data['secret']
+      now            = DateTime.parse(test_data['now']).to_time
+      expected_token = test_data['token']
+
+      generator = Fernet::Generator.new(secret:   secret,
+                                        key_bits: 256,
+                                        message:  message,
+                                        iv:       iv,
+                                        now:      now)
+
+      expect(generator.generate).to eq(expected_token)
+    end
+  end
+
 end

--- a/spec/acceptance/verify_spec.rb
+++ b/spec/acceptance/verify_spec.rb
@@ -4,7 +4,53 @@ require 'json'
 require 'base64'
 
 describe Fernet::Verifier do
-  it 'verifies tokens according to the spec' do
+  it 'verifies tokens according to the spec for AES128' do
+    path = File.expand_path(
+      './../fernet-spec/verify.json', File.dirname(__FILE__)
+    )
+    verify_json  = JSON.parse(File.read(path))
+
+    verify_json.each do |test_data|
+      token   = test_data['token']
+      ttl     = test_data['ttl_sec']
+      now     = DateTime.parse(test_data['now']).to_time
+      secret  = test_data['secret']
+      message = test_data['src']
+
+      verifier = Fernet::Verifier.new(token: token,
+                                      secret: secret,
+                                      now: now,
+                                      ttl: ttl)
+      expect(
+        verifier.message
+      ).to eq(message)
+    end
+  end
+
+  it 'verifies tokens according to the spec for AES192' do
+    path = File.expand_path(
+      './../fernet-spec/verify.json', File.dirname(__FILE__)
+    )
+    verify_json  = JSON.parse(File.read(path))
+
+    verify_json.each do |test_data|
+      token   = test_data['token']
+      ttl     = test_data['ttl_sec']
+      now     = DateTime.parse(test_data['now']).to_time
+      secret  = test_data['secret']
+      message = test_data['src']
+
+      verifier = Fernet::Verifier.new(token: token,
+                                      secret: secret,
+                                      now: now,
+                                      ttl: ttl)
+      expect(
+        verifier.message
+      ).to eq(message)
+    end
+  end
+
+  it 'verifies tokens according to the spec for AES256' do
     path = File.expand_path(
       './../fernet-spec/verify.json', File.dirname(__FILE__)
     )

--- a/spec/fernet_spec.rb
+++ b/spec/fernet_spec.rb
@@ -6,21 +6,43 @@ require 'fernet'
 describe Fernet do
   after { Fernet::Configuration.run }
 
-  let(:secret)     { 'JrdICDH6x3M7duQeM8dJEMK4Y5TkBIsYDw1lPy35RiY=' }
+  let(:secret128)  { 'JrdICDH6x3M7duQeM8dJEMK4Y5TkBIsYDw1lPy35RiY=' }
+  let(:secret192)  { 'HE_GGEDrDA3L2GJBaoFPkQseOzSjAi1aPSTil0PL5p5eJwYHuvvQMPRphvTW-EUl' }
+  let(:secret256)  { 'iad7Z_H9a0BGsWoNz-7SbDon9URcuCECWb0QbTJk2MrD8_DWQvShFXUB_MxAkSly6WbzO6DmfTF_prBYV5NL7A==' }
   let(:bad_secret) { 'badICDH6x3M7duQeM8dJEMK4Y5TkBIsYDw1lPy35RiY=' }
 
-  it 'can verify tokens it generates' do
+  it 'can verify tokens it generates for AES128' do
     ['harold@heroku.com', '12345', 'weird!@#$%^&*()chars', 'more weird chars §§§§'].each do |plain|
-      token = Fernet.generate(secret, plain)
+      token = Fernet.generate(secret128, plain)
 
-      verifier = Fernet.verifier(secret, token)
+      verifier = Fernet.verifier(secret128, token)
+      expect(verifier).to be_valid
+      expect(verifier.message).to eq(plain)
+    end
+  end
+
+  it 'can verify tokens it generates for AES192' do
+    ['harold@heroku.com', '12345', 'weird!@#$%^&*()chars', 'more weird chars §§§§'].each do |plain|
+      token = Fernet.generate(secret192, plain)
+
+      verifier = Fernet.verifier(secret192, token)
+      expect(verifier).to be_valid
+      expect(verifier.message).to eq(plain)
+    end
+  end
+
+  it 'can verify tokens it generates for AES256' do
+    ['harold@heroku.com', '12345', 'weird!@#$%^&*()chars', 'more weird chars §§§§'].each do |plain|
+      token = Fernet.generate(secret256, plain)
+
+      verifier = Fernet.verifier(secret256, token)
       expect(verifier).to be_valid
       expect(verifier.message).to eq(plain)
     end
   end
 
   it 'fails with a bad secret' do
-    token = Fernet.generate(secret, 'harold@heroku.com')
+    token = Fernet.generate(secret128, 'harold@heroku.com')
 
     verifier = Fernet.verifier(bad_secret, token)
     expect(verifier.valid?).to eq(false)
@@ -30,9 +52,9 @@ describe Fernet do
   end
 
   it 'fails if the token is too old' do
-    token = Fernet.generate(secret, 'harold@heroku.com', now: (Time.now - 61))
+    token = Fernet.generate(secret128, 'harold@heroku.com', now: (Time.now - 61))
 
-    verifier = Fernet.verifier(secret, token)
+    verifier = Fernet.verifier(secret128, token)
     expect(verifier.valid?).to eq(false)
   end
 
@@ -41,9 +63,9 @@ describe Fernet do
       config.enforce_ttl = true
     end
 
-    token = Fernet.generate(secret, 'harold@heroku.com')
+    token = Fernet.generate(secret128, 'harold@heroku.com')
 
-    verifier = Fernet.verifier(secret, token, enforce_ttl: false,
+    verifier = Fernet.verifier(secret128, token, enforce_ttl: false,
                                               now: Time.now + 9999)
     expect(verifier.valid?).to eq(true)
   end
@@ -53,14 +75,14 @@ describe Fernet do
       config.enforce_ttl = false
     end
 
-    token = Fernet.generate(secret, 'harold@heroku.com')
+    token = Fernet.generate(secret128, 'harold@heroku.com')
 
-    verifier = Fernet.verifier(secret, token, now: Time.now + 999999)
+    verifier = Fernet.verifier(secret128, token, now: Time.now + 999999)
     expect(verifier.valid?).to eq(true)
   end
 
   it 'does not send the message in plain text' do
-    token = Fernet.generate(secret, 'password1')
+    token = Fernet.generate(secret128, 'password1')
 
     expect(Base64.urlsafe_decode64(token)).not_to match /password1/
   end
@@ -70,8 +92,8 @@ describe Fernet do
       config.enforce_ttl = true
       config.ttl = 0
     end
-    token = Fernet.generate(secret, 'password1')
-    verifier = Fernet.verifier(secret, token, now: Time.now + 999999)
+    token = Fernet.generate(secret128, 'password1')
+    verifier = Fernet.verifier(secret128, token, now: Time.now + 999999)
     verifier.enforce_ttl = false
     expect(verifier.valid?).to eq(true)
     expect(verifier.message).to eq('password1')

--- a/spec/secret_spec.rb
+++ b/spec/secret_spec.rb
@@ -3,33 +3,58 @@ require 'fernet/secret'
 
 describe Fernet::Secret do
   it "can resolve a URL safe base64 encoded 32 byte string" do
-    resolves_input(Base64.urlsafe_encode64("A"*16 + "B"*16))
+    resolves_input(Base64.urlsafe_encode64("A"*16 + "B"*16), 128)
   end
 
   it "can resolve a base64 encoded 32 byte string" do
-    resolves_input(Base64.encode64("A"*16 + "B"*16))
+    resolves_input(Base64.encode64("A"*16 + "B"*16), 128)
   end
 
   it "can resolve a 32 byte string without encoding" do
-    resolves_input("A"*16 + "B"*16)
+    resolves_input("A"*16 + "B"*16, 128)
+  end
+
+  it "can resolve a URL safe base64 encoded 48 byte string for AES192" do
+    resolves_input(Base64.urlsafe_encode64("A"*24 + "B"*24), 192)
+  end
+
+  it "can resolve a base64 encoded 48 byte string for AES192" do
+    resolves_input(Base64.encode64("A"*24 + "B"*24), 192)
+  end
+
+  it "can resolve a 48 byte string without encoding for AES192" do
+    resolves_input("A"*24 + "B"*24, 192)
+  end
+
+  it "can resolve a URL safe base64 encoded 64 byte string for AES256" do
+    resolves_input(Base64.urlsafe_encode64("A"*32 + "B"*32), 256)
+  end
+
+  it "can resolve a base64 encoded 64 byte string for AES256" do
+    resolves_input(Base64.encode64("A"*32 + "B"*32), 256)
+  end
+
+  it "can resolve a 64 byte string without encoding for AES256" do
+    resolves_input("A"*32 + "B"*32, 256)
   end
 
   it "fails loudly when an invalid secret is provided" do
     secret = Base64.urlsafe_encode64("bad")
     expect do
-      Fernet::Secret.new(secret)
+      Fernet::Secret.new(secret, 128)
     end.to raise_error(Fernet::Secret::InvalidSecret)
   end
 
-  def resolves_input(input)
-    secret = Fernet::Secret.new(input)
+  def resolves_input(input, key_bits)
+    secret = Fernet::Secret.new(input, key_bits)
+    key_bytes = key_bits / 8
 
     expect(
       secret.signing_key
-    ).to eq("A"*16)
+    ).to eq("A"*key_bytes)
 
     expect(
       secret.encryption_key
-    ).to eq("B"*16)
+    ).to eq("B"*key_bytes)
   end
 end

--- a/spec/token_spec.rb
+++ b/spec/token_spec.rb
@@ -131,4 +131,47 @@ describe Fernet::Token, 'message' do
 
     expect(token.message).to eq('')
   end
+
+  it 'correctly returns the key length for a version' do
+    key_bits = Fernet::Token.version_key_bits(0x80)
+    expect(key_bits).to eq(128)
+
+    key_bits = Fernet::Token.version_key_bits(0xA0)
+    expect(key_bits).to eq(192)
+
+    key_bits = Fernet::Token.version_key_bits(0xC0)
+    expect(key_bits).to eq(256)
+  end
+
+  it 'correctly handles key length for invalid versions' do
+    key_bits = Fernet::Token.version_key_bits(0x90)
+    expect(key_bits).to eq(0)
+  end
+
+  it 'correctly returns the spec revision' do
+    rev = Fernet::Token.version_revision(0x80)
+    expect(rev).to eq(0)
+
+    rev = Fernet::Token.version_revision(0xA0)
+    expect(rev).to eq(0)
+
+    rev = Fernet::Token.version_revision(0xC0)
+    expect(rev).to eq(0)
+  end
+
+  it 'correctly builds a version byte' do
+    v = Fernet::Token.make_version(128, 0)
+    expect(v).to eq(0x80)
+
+    v = Fernet::Token.make_version(192, 0)
+    expect(v).to eq(0xA0)
+
+    v = Fernet::Token.make_version(256, 0)
+    expect(v).to eq(0xC0)
+  end
+
+  it 'correctly builds a version byte for an invalid key length' do
+    v = Fernet::Token.make_version(150, 7)
+    expect(v).to eq(0)
+  end
 end

--- a/spec/token_spec.rb
+++ b/spec/token_spec.rb
@@ -3,82 +3,92 @@ require 'fernet'
 require 'json'
 
 describe Fernet::Token, 'validation' do
-  let(:secret) { 'odN/0Yu+Pwp3oIvvG8OiE5w4LsLrqfWYRb3knQtSyKI=' }
+  let(:secret128) { 'odN/0Yu+Pwp3oIvvG8OiE5w4LsLrqfWYRb3knQtSyKI=' }
+  let(:secret192) { 'HE_GGEDrDA3L2GJBaoFPkQseOzSjAi1aPSTil0PL5p5eJwYHuvvQMPRphvTW-EUl' }
+  let(:secret256) { 'iad7Z_H9a0BGsWoNz-7SbDon9URcuCECWb0QbTJk2MrD8_DWQvShFXUB_MxAkSly6WbzO6DmfTF_prBYV5NL7A==' }
+
   it 'is invalid with a bad MAC signature' do
-    generated = Fernet::Token.generate(secret: secret,
+    generated = Fernet::Token.generate(secret: secret128,
                                        message: 'hello')
 
     bogus_hmac = "1" * 32
     allow(Fernet::Encryption).to receive(:hmac_digest).and_return(bogus_hmac)
 
-    token = Fernet::Token.new(generated.to_s, secret: secret)
+    token = Fernet::Token.new(generated.to_s, secret: secret128)
 
     expect(token.valid?).to eq(false)
     expect(token.errors[:signature]).to include("does not match")
   end
 
   it 'is invalid if too old' do
-    generated = Fernet::Token.generate(secret: secret,
+    generated = Fernet::Token.generate(secret: secret128,
                                        message: 'hello',
                                        now: Time.now - 61)
     token = Fernet::Token.new(generated.to_s, enforce_ttl: true,
                                               ttl: 60,
-                                              secret: secret)
+                                              secret: secret128)
     expect(token.valid?).to eq(false)
     expect(token.errors[:issued_timestamp]).to include("is too far in the past: token expired")
   end
 
   it 'is invalid with a large clock skew' do
-    generated = Fernet::Token.generate(secret:  secret,
+    generated = Fernet::Token.generate(secret:  secret128,
                                        message: 'hello',
                                        now:     Time.at(Time.now.to_i + 61))
-    token = Fernet::Token.new(generated.to_s, secret: secret)
+    token = Fernet::Token.new(generated.to_s, secret: secret128)
 
     expect(token.valid?).to eq(false)
     expect(token.errors[:issued_timestamp]).to include("is too far in the future")
   end
 
   it 'is invalid with bad base64' do
-    token = Fernet::Token.new('bad', secret: secret)
+    token = Fernet::Token.new('bad', secret: secret128)
 
     expect(token.valid?).to eq(false)
     expect(token.errors[:token]).to include("invalid base64")
   end
 
   it 'is invalid with an unknown token version' do
-    invalid1 = Fernet::Token.generate(message: 'message', version: 0x00, secret: secret)
-    invalid2 = Fernet::Token.generate(message: 'message', version: 0x81, secret: secret)
-    valid    = Fernet::Token.generate(message: 'message', secret: secret)
+    invalid1 = Fernet::Token.generate(message: 'message', version: 0x00, secret: secret128)
+    invalid2 = Fernet::Token.generate(message: 'message', version: 0x81, secret: secret128)
+    valid128 = Fernet::Token.generate(message: 'message', secret: secret128)
+    valid192 = Fernet::Token.generate(message: 'message', secret: secret192, key_bits: 192)
+    valid256 = Fernet::Token.generate(message: 'message', secret: secret256, key_bits: 256)
 
     [invalid1, invalid2].each do |token|
       expect(token.valid?).to eq(false)
       expect(token.errors[:version]).to include("is unknown")
     end
-    expect(valid.valid?).to eq(true)
+    expect(valid128.valid?).to eq(true)
+    expect(valid192.valid?).to eq(true)
+    expect(valid256.valid?).to eq(true)
   end
 
   it 'is invalid with bad base64 encodings' do
-    token = Fernet::Token.generate(message: 'message', secret: secret)
-    invalid = Fernet::Token.new("\n#{token}", secret: secret)
+    token = Fernet::Token.generate(message: 'message', secret: secret128)
+    invalid = Fernet::Token.new("\n#{token}", secret: secret128)
 
     ["\n#{token}", "#{token} ", "#{token}+",
       token.to_s.gsub(/(.)$/, "1"),
       token.to_s.gsub(/(.)$/, "+"),
       token.to_s.gsub(/(.)$/, "\\"),
     ].each do |invalid_string|
-      invalid = Fernet::Token.new(invalid_string, secret: secret)
+      invalid = Fernet::Token.new(invalid_string, secret: secret128)
       expect(invalid.valid?).to be(false)
     end
   end
 end
 
 describe Fernet::Token, 'message' do
-  let(:secret) { 'odN/0Yu+Pwp3oIvvG8OiE5w4LsLrqfWYRb3knQtSyKI=' }
+  let(:secret128) { 'odN/0Yu+Pwp3oIvvG8OiE5w4LsLrqfWYRb3knQtSyKI=' }
+  let(:secret192) { 'HE_GGEDrDA3L2GJBaoFPkQseOzSjAi1aPSTil0PL5p5eJwYHuvvQMPRphvTW-EUl' }
+  let(:secret256) { 'iad7Z_H9a0BGsWoNz-7SbDon9URcuCECWb0QbTJk2MrD8_DWQvShFXUB_MxAkSly6WbzO6DmfTF_prBYV5NL7A==' }
+
   it 'refuses to decrypt if invalid' do
-    generated = Fernet::Token.generate(secret:  secret,
+    generated = Fernet::Token.generate(secret:  secret128,
                                        message: 'hello',
                                        now:     Time.now + 61)
-    token = Fernet::Token.new(generated.to_s, secret: secret)
+    token = Fernet::Token.new(generated.to_s, secret: secret128)
 
     !token.valid? or raise "invalid token"
 
@@ -88,8 +98,26 @@ describe Fernet::Token, 'message' do
       /issued_timestamp is too far in the future/
   end
 
-  it 'gives back the original message in plain text' do
-    token = Fernet::Token.generate(secret: secret,
+  it 'gives back the original message in plain text for AES128' do
+    token = Fernet::Token.generate(secret: secret128,
+                                   message: 'hello')
+    token.valid? or raise "invalid token"
+
+    expect(token.message).to eq('hello')
+  end
+
+  it 'gives back the original message in plain text for AES192' do
+    token = Fernet::Token.generate(secret: secret192,
+                                   key_bits: 192,
+                                   message: 'hello')
+    token.valid? or raise "invalid token"
+
+    expect(token.message).to eq('hello')
+  end
+
+  it 'gives back the original message in plain text for AES256' do
+    token = Fernet::Token.generate(secret: secret256,
+                                   key_bits: 256,
                                    message: 'hello')
     token.valid? or raise "invalid token"
 
@@ -97,7 +125,7 @@ describe Fernet::Token, 'message' do
   end
 
   it 'correctly handles an empty message' do
-    token = Fernet::Token.generate(secret: secret,
+    token = Fernet::Token.generate(secret: secret128,
                                    message: '')
     token.valid? or raise "invalid token"
 


### PR DESCRIPTION
Add AES192 and AES256 as supported encryption methods.
Add version bytes to distinguish between AES128, AES192 and AES256 encryption in tokens.
Goes with fernet/spec#17