### PR TITLE
Version bump and support more modern ciphers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.1
 
 # install fresh version of bundler, since older ones blow up trying to install
 # rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3
 
 # install fresh version of bundler, since older ones blow up trying to install
 # rspec

--- a/fernet.gemspec
+++ b/fernet.gemspec
@@ -4,7 +4,7 @@ require File.expand_path('../lib/fernet/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.authors      = ["Harold Giménez"]
   gem.email        = ["harold.gimenez@gmail.com"]
-  gem.description  = "Delicious HMAC Digest(if) authentication and AES-128-CBC encryption"
+  gem.description  = "Delicious HMAC Digest(if) authentication and AES-128-GCM encryption"
   gem.summary      = "Easily generate and verify AES encrypted HMAC based authentication tokens"
   gem.homepage     = "https://github.com/fernet/fernet-rb"
 

--- a/lib/fernet/encryption.rb
+++ b/lib/fernet/encryption.rb
@@ -5,7 +5,7 @@ module Fernet
   module Encryption
     AES_BLOCK_SIZE  = 16.freeze
 
-    # Internal: Encrypts the provided message using a AES-128-CBC cipher with a
+    # Internal: Encrypts the provided message using a AES-128-GCM cipher with a
     #   random IV and the provided encryption key
     #
     # opts - a hash containing
@@ -21,7 +21,7 @@ module Fernet
     #
     # Returns a two-element array containing the ciphertext and the random IV
     def self.encrypt(opts)
-      cipher = OpenSSL::Cipher.new('AES-128-CBC')
+      cipher = OpenSSL::Cipher.new('aes-128-gcm')
       cipher.encrypt
       iv = opts[:iv] || cipher.random_iv
       cipher.iv  = iv
@@ -34,7 +34,7 @@ module Fernet
       [ciphertext, iv]
     end
 
-    # Internal: Decrypts the provided ciphertext using a AES-128-CBC cipher with a
+    # Internal: Decrypts the provided ciphertext using a AES-128-GCM cipher with a
     #   the provided IV and encryption key
     #
     # opts - a hash containing
@@ -50,7 +50,7 @@ module Fernet
     #
     # Returns a two-element array containing the ciphertext and the random IV
     def self.decrypt(opts)
-      decipher = OpenSSL::Cipher.new('AES-128-CBC')
+      decipher = OpenSSL::Cipher.new('aes-128-gcm')
       decipher.decrypt
       decipher.iv  = opts[:iv]
       decipher.key = opts[:key]

--- a/lib/fernet/version.rb
+++ b/lib/fernet/version.rb
@@ -1,3 +1,3 @@
 module Fernet
-  VERSION = "2.2"
+  VERSION = "3.0.pre1"
 end


### PR DESCRIPTION
I recently received a review of one of my apps that uses this at work and they noticed that the openssl cipher could be improved. This change updates to the newer, preferred, `aes-128-gcm` cipher where `aes-128-cbc` was used previously.

* I've created this change as a major version change but as a pre-release so we can try it out before it becomes the default when people require fernet.
* I don't have a solid story for what an upgrade path looks like, but I don't think it should discourage people using this on new projects from using a better cipher perspective.
* I'm not a crypto person and have no clue if there's more than just swapping out the ciphers.